### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,54 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+        env:
+          CI: false
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: build
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
This PR adds a GitHub Actions workflow to automatically build and deploy the project to GitHub Pages on every push to the main/master branches.

## Key Changes
- Added `.github/workflows/deploy.yml` with a two-job CI/CD pipeline:
  - **Build job**: Checks out code, sets up Node.js 20, installs dependencies, and builds the project
  - **Deploy job**: Deploys the built artifacts to GitHub Pages
- Configured to trigger on pushes to `main` and `master` branches, plus manual workflow dispatch
- Set appropriate permissions for GitHub Pages deployment (contents read, pages write, id-token write)
- Enabled concurrency control to cancel in-progress deployments when new ones are triggered

## Implementation Details
- Uses Node.js 20 with npm caching for faster builds
- Builds to the `build` directory which is uploaded as a GitHub Pages artifact
- Sets `CI=false` environment variable during build to avoid treating warnings as errors
- Uses latest stable versions of GitHub Actions (checkout@v4, setup-node@v4, upload-pages-artifact@v3, deploy-pages@v4)

https://claude.ai/code/session_014G7LJgohtQLTXqQcVDU36F